### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ let observer = PropertyObserver(observed: self.scrollView, events: [
 
 ## Requirements
 
-If installing using Cocoapods, then a deployment target of iOS 8 or higher is required due to dynamic framework linking.
+If installing using CocoaPods, then a deployment target of iOS 8 or higher is required due to dynamic framework linking.
 
 If you prefer to install manually then the minimum deployment target is loosened to iOS 7 or higher due to Swift not being available for iOS 6 and below.
 
 ## Installation
 
-#### Cocoapods
+#### CocoaPods
 
 SwiftKVO is available through [CocoaPods](http://cocoapods.org). To install it, simply add the following line to your Podfile:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
